### PR TITLE
adding in visted state for green btn

### DIFF
--- a/app/assets/stylesheets/ama_layout/layout/buttons.scss
+++ b/app/assets/stylesheets/ama_layout/layout/buttons.scss
@@ -31,7 +31,7 @@ button.disabled, button[disabled], .button.disabled, .button[disabled]{
    background-color: lighten($brand-red, 10%);
   }
 }
-.green-btn{
+.green-btn, .green-btn:visited{
   @extend .base-button;
   background: $brand-green;
   &:hover, &:active, &:focus{


### PR DESCRIPTION
We were missing the visited state in the CSS for the green-btn class. 