### PR TITLE
This padding was defined inline in membership for the h5 within panel-title

### DIFF
--- a/app/assets/stylesheets/ama_layout/layout/helper-classes.scss
+++ b/app/assets/stylesheets/ama_layout/layout/helper-classes.scss
@@ -75,7 +75,8 @@
   padding: $base-padding*2;
 
   h5{
-    color :$jet;
+    color: $jet;
+    padding-left: 10px;
   }
 }
 

--- a/lib/ama_layout/version.rb
+++ b/lib/ama_layout/version.rb
@@ -1,3 +1,3 @@
 module AmaLayout
-  VERSION = "1.1.9"
+  VERSION = "1.1.10"
 end


### PR DESCRIPTION
- There are h5 used elsewhere, but they specify pl0 which overrides this rule