### PR TITLE
Capitalize all form labels

### DIFF
--- a/app/assets/stylesheets/ama_layout/layout_components/forms.scss
+++ b/app/assets/stylesheets/ama_layout/layout_components/forms.scss
@@ -1,3 +1,9 @@
+form * {
+  label {
+    text-transform: capitalize;
+  }
+}
+
 .membership-card-radio{
   text-align:center;
   padding: 0;

--- a/lib/ama_layout/version.rb
+++ b/lib/ama_layout/version.rb
@@ -1,3 +1,3 @@
 module AmaLayout
-  VERSION = "1.1.13"
+  VERSION = "1.2.0"
 end


### PR DESCRIPTION
* Currently we capitalize all the form fields using a
simple_form initializer. However, this is throwing some errors in edge
cases.
* Wrapped this in a form and http://www.w3.org/TR/selectors/#descendant-combinators
after talking with @kaytcampbell. This will make sure that we create all
form elements inside of an actual form element. All new styling for this
file should be nested under form * too (we'll move the rest over as we
go)