### PR TITLE
bind a resize event to adjust the footer

### DIFF
--- a/app/assets/javascripts/ama_layout/desktop/sticky-footer.coffee
+++ b/app/assets/javascripts/ama_layout/desktop/sticky-footer.coffee
@@ -1,16 +1,23 @@
-$(window).bind "load", ->
-  adjustFooter = ->
-    $("footer").css({ 'margin-top': calcHeight() + 'px' })
+$(window).bind
+  load: ->
+    adjustFooter()
+    accordionAdjust()
+  resize: ->
+    adjustFooter()
+    accordionAdjust()
 
-  calcHeight = ->
-    footer = $("footer")
-    position = footer.position()
-    footer_top = if position is undefined then 0 else position.top
-    height = $(window).height() - footer_top - footer.height()
-    Math.max(height, 50)
+adjustFooter = ->
+  $("footer").css({ 'margin-top': calcHeight() + 'px' })
 
-  adjustFooter()
+accordionAdjust = ->
   $("a.asset-link.clearfix").click ->
     setTimeout ->
       adjustFooter()
     , 1
+
+calcHeight = ->
+  footer = $("footer")
+  position = footer.position()
+  footer_top = if position is undefined then 0 else position.top
+  height = $(window).height() - footer_top - footer.height()
+  Math.max(height, 50)

--- a/lib/ama_layout/version.rb
+++ b/lib/ama_layout/version.rb
@@ -1,3 +1,3 @@
 module AmaLayout
-  VERSION = "1.1.22"
+  VERSION = "1.1.23"
 end


### PR DESCRIPTION
* Because when the user resize the page the footer does not
stick to the button. Added a resize event and refactor to have
the events just call methods to adjust the footer.