### PR TITLE
fixing hint class to show up better

### DIFF
--- a/app/assets/stylesheets/ama_layout/layout_components/forms.scss
+++ b/app/assets/stylesheets/ama_layout/layout_components/forms.scss
@@ -164,7 +164,8 @@ input[type="checkbox"]:checked + label{
 
 p.hint{
   font-size: $base-font-size*0.85;
-  color: $smoke;
+  color: darken($smoke, 15%);
+  font-style: italic;
 }
 
 /* ------------- Error Messaging ------------- */

--- a/lib/ama_layout/version.rb
+++ b/lib/ama_layout/version.rb
@@ -1,3 +1,3 @@
 module AmaLayout
-  VERSION = "2.2.0"
+  VERSION = "2.2.1"
 end


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1906696/11483762/7eb9d124-9767-11e5-9259-4b0adce1bb6b.png)
https://ama-digital.myjetbrains.com/youtrack/issue/DEOE-1042

Makes colour on .hint darker and also italic so it's easier to read.