### PR TITLE
fixes markup errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 *.a
 mkmf.log
 *.gem
+vendor/

--- a/app/assets/stylesheets/ama_layout/foundation_and_overrides.scss
+++ b/app/assets/stylesheets/ama_layout/foundation_and_overrides.scss
@@ -1404,8 +1404,8 @@ $topbar-bg-color: $brand-blue-dark;
 $topbar-bg: $topbar-bg-color;
 
 // Height and margin
-$topbar-height: 50px;
-$topbar-margin-bottom: 30px;
+$topbar-height: rem-calc(50);
+$topbar-margin-bottom: rem-calc(30);
 
 // Controlling the styles for the title in the top bar
 // $topbar-title-weight: $font-weight-normal;

--- a/app/views/ama_layout/_main_nav_item.html.erb
+++ b/app/views/ama_layout/_main_nav_item.html.erb
@@ -1,7 +1,7 @@
 <li class="dashboard-nav dashboard-title <%= nav_item.active_class %>">
   <span class="nav-icon fa <%= nav_item.icon %> <%= nav_item.active_class %>"></span>
   <%= link_to nav_item.text, nav_item.link,
-      target: nav_item.target, alt: nav_item.alt,
+      target: nav_item.target,
       class: nav_item.active_class %>
   <%= nav_item.sidebar_sub_nav %>
 </li>

--- a/app/views/ama_layout/_sidebar.html.erb
+++ b/app/views/ama_layout/_sidebar.html.erb
@@ -1,11 +1,11 @@
 <div class="medium-4 large-3 columns show-for-medium-up pl0">
   <div class="white-trans pb0">
-    <div class="large-12 fullwidth center">
+    <ul class="large-12 fullwidth center">
       <%= render partial: "ama_layout/main_nav_item", collection: navigation.items, as: :nav_item %>
       <li class="dashboard-nav dashboard-title">
         <span class="nav-icon fa fa-power-off"></span>
         <%= link_to "Sign Out", "/logout" %>
       </li>
-    </div>
+    </ul>
   </div>
 </div>

--- a/lib/ama_layout/version.rb
+++ b/lib/ama_layout/version.rb
@@ -1,3 +1,3 @@
 module AmaLayout
-  VERSION = '2.4.5'
+  VERSION = '3.0.0'
 end


### PR DESCRIPTION
https://validator.w3.org/nu

Checked markup against HTML5 Nu validator (above). Fixes the following
errors:
  * Error: Element li not allowed as child of element div in this context.
  * Error: Attribute alt not allowed on element a at this point.

* Also fixes Sass::UnitConversionError