### PR TITLE
Fixing a couple of the paths which didn't exist

### DIFF
--- a/app/assets/stylesheets/ama_layout/webfonts/ss-symbolicons-block.scss
+++ b/app/assets/stylesheets/ama_layout/webfonts/ss-symbolicons-block.scss
@@ -12,10 +12,10 @@
 
 @font-face {
   font-family: "SSSymbolicons";
-  src: asset-url('ama_layout/webfonts/stylesheets/webfonts/ss-symbolicons-block.eot');
+  src: asset-url('ama_layout/webfonts/ss-symbolicons-block.eot');
   src: asset-url('ama_layout/webfonts/ss-symbolicons-block.eot?#iefix') format('embedded-opentype'),
        asset-url('ama_layout/webfonts/ss-symbolicons-block.woff') format('woff'),
-       asset-url('ama_layout/webfonts/stylesheets/ama_layout/webfonts/ss-symbolicons-block.ttf')  format('truetype'),
+       asset-url('ama_layout/webfonts/ss-symbolicons-block.ttf')  format('truetype'),
        asset-url('ama_layout/webfonts/ss-symbolicons-block.svg#SSSymboliconsBlock') format('svg');
   font-weight: normal;
   font-style: normal;

--- a/lib/ama_layout/version.rb
+++ b/lib/ama_layout/version.rb
@@ -1,3 +1,3 @@
 module AmaLayout
-  VERSION = '3.1.1'
+  VERSION = '3.1.2'
 end


### PR DESCRIPTION
- Those 2 paths don't exist in this project

🎨 

Automotive still loads the icons properly:
![image](https://cloud.githubusercontent.com/assets/473578/15874044/a5a488c8-2cbe-11e6-8668-277231150b27.png)
