### PR TITLE
Updating padding for reveal modals

### DIFF
--- a/app/assets/stylesheets/ama_layout/_settings.scss
+++ b/app/assets/stylesheets/ama_layout/_settings.scss
@@ -453,7 +453,7 @@ $progress-radius: $global-radius;
 $reveal-background: $white;
 $reveal-width: 960px;
 $reveal-max-width: $global-width;
-$reveal-padding: $global-padding;
+$reveal-padding: 0;
 $reveal-border: 1px solid $medium-gray;
 $reveal-radius: $global-radius;
 $reveal-zindex: 1005;

--- a/app/assets/stylesheets/ama_layout/layout_components/reveal-modal.scss
+++ b/app/assets/stylesheets/ama_layout/layout_components/reveal-modal.scss
@@ -9,3 +9,9 @@ dialog .close-reveal-modal{
   font-weight: bold;
   cursor: pointer;
 }
+
+@include breakpoint(small only){
+  .reveal{
+    padding: $global-padding $global-padding 51px $global-padding; // 51 pixels to offset the height of the top bar
+  }
+}

--- a/lib/ama_layout/version.rb
+++ b/lib/ama_layout/version.rb
@@ -1,3 +1,3 @@
 module AmaLayout
-  VERSION = '3.2.0'
+  VERSION = '3.2.1'
 end


### PR DESCRIPTION
- Set overall padding to 0px to not interfere with elements within the modal.
- Overriding mobile reveal bottom padding to equal titlebar height, so it isn't pushed off the bottom of the viewport.

🎨 