### PR TITLE
replaces display:none with visibility: hidden

### DIFF
--- a/app/assets/stylesheets/ama_layout/layout_components/forms.scss
+++ b/app/assets/stylesheets/ama_layout/layout_components/forms.scss
@@ -180,7 +180,7 @@ input[type="checkbox"]:checked + label{
 }
 
 input[type="checkbox"]{
-  display: none;
+  visibility: hidden;
 }
 
 @keyframes checkbox{


### PR DESCRIPTION
🎨 
https://developers.google.com/web/fundamentals/performance/critical-rendering-path/render-tree-construction?hl=en

* This is to fix failing tests in https://github.com/amaabca/registries/tree/design-refresh because Capybara can't interact with hidden elements (because the nodes don't actually exist in the render
tree). The link above does a good job of explaining
* The checkbox  still occupies space in the layout but this shouldn't
cause issues because we position the checkbox off the screen here:
https://github.com/amaabca/ama_layout/blob/master/app/assets/stylesheets/ama_layout/layout_components/forms.scss#L63


![screen shot 2016-07-06 at 13 41 05](https://cloud.githubusercontent.com/assets/547777/16632128/de31a73e-437f-11e6-8261-83d2efddf145.png)