### PR TITLE
ribbon css was only included in radio-third class

### DIFF
--- a/app/assets/stylesheets/ama_layout/layout_components/comparison-radios.scss
+++ b/app/assets/stylesheets/ama_layout/layout_components/comparison-radios.scss
@@ -1,3 +1,12 @@
+@mixin best-value-ribbon{
+  &:nth-of-type(1),
+  &:nth-of-type(3){
+    .comparison-radios__ribbon{ //only display the ribbon for the middle radio
+      display: none;
+    }
+  }
+}
+
 .comparison-radios{
   &__wrapper{
     @include grid-row-nest;
@@ -7,17 +16,12 @@
 
   &__radio-half{
     @include medium-6;
+    @include best-value-ribbon;
   }
 
   &__radio-third{
     @include medium-4;
-
-    &:nth-of-type(1),
-    &:nth-of-type(3){
-      .comparison-radios__ribbon{ //only display the ribbon for the middle radio
-        display: none;
-      }
-    }
+    @include best-value-ribbon;
   }
 
   &--vertical{


### PR DESCRIPTION
🎨 
* Change the ribbon related css to be a mixin to avoid
repetition because it have to be added to __radio-half and
__radio-third.