### PR TITLE
Email Address Top Nav

### DIFF
--- a/app/assets/stylesheets/ama_layout/layout_components/comparison-radios.scss
+++ b/app/assets/stylesheets/ama_layout/layout_components/comparison-radios.scss
@@ -88,6 +88,7 @@
   }
 
   &__image{
+    height: 125px;
     margin-bottom: $base-margin;
   }
 

--- a/app/views/ama_layout/_top_nav.html.erb
+++ b/app/views/ama_layout/_top_nav.html.erb
@@ -1,5 +1,5 @@
 <li class="has-submenu">
-  <%= link_to navigation.user.email.truncate(30), Rails.configuration.gatekeeper_site %>
+  <%= link_to navigation.display_name_text, '#' %>
   <ul class="submenu menu vertical">
     <li><%= link_to 'AMA Website', Rails.configuration.amaabca_site %></li>
     <li><a href="http://amaroadreports.ca/">AMA Road Reports</a></li>

--- a/app/views/ama_layout/_top_nav.html.erb
+++ b/app/views/ama_layout/_top_nav.html.erb
@@ -1,8 +1,8 @@
 <li class="has-submenu">
-  <a>Welcome, %%BATMAN%%</a>
+  <%= link_to navigation.user.email.truncate(30), Rails.configuration.gatekeeper_site %>
   <ul class="submenu menu vertical">
-    <li><a href="<%= Rails.configuration.amaabca_site %>">AMA Website</a></li>
+    <li><%= link_to 'AMA Website', Rails.configuration.amaabca_site %></li>
     <li><a href="http://amaroadreports.ca/">AMA Road Reports</a></li>
-    <li><a href="/logout">Sign Out</a></li>
+    <%= navigation.sign_out_link %>
   </ul>
 </li>

--- a/lib/ama_layout/decorators/navigation_decorator.rb
+++ b/lib/ama_layout/decorators/navigation_decorator.rb
@@ -6,6 +6,10 @@ module AmaLayout
       object.items.map { |i| i.decorate }
     end
 
+    def display_name_text
+      (display_email? && email || "Welcome, #{display_name}").truncate(30)
+    end
+
     def sign_out_link
       return "" unless user
       h.content_tag :li, class: "side-nav__item" do

--- a/lib/ama_layout/decorators/navigation_decorator.rb
+++ b/lib/ama_layout/decorators/navigation_decorator.rb
@@ -7,7 +7,7 @@ module AmaLayout
     end
 
     def display_name_text
-      (display_email? && email || "Welcome, #{display_name}").truncate(30)
+      name_or_email.truncate(30)
     end
 
     def sign_out_link
@@ -23,6 +23,10 @@ module AmaLayout
 
     def sidebar
       h.render partial: "ama_layout/sidebar", locals: { navigation: self } if items.any?
+    end
+
+    def name_or_email
+      display_name.present? ? "Welcome, #{display_name.titleize}" : email
     end
   end
 end

--- a/lib/ama_layout/navigation.rb
+++ b/lib/ama_layout/navigation.rb
@@ -3,8 +3,7 @@ module AmaLayout
     include ActiveModel::Model
     include Draper::Decoratable
 
-    attr_writer :display_name
-    attr_accessor :user, :current_url, :nav_file_path
+    attr_accessor :user, :current_url, :nav_file_path, :display_name
 
     def initialize(args = {})
       args = defaults.merge args
@@ -34,16 +33,8 @@ module AmaLayout
       YAML.load ERB.new(File.read nav_file_path).result
     end
 
-    def display_name
-      @display_name && @display_name.titleize || email
-    end
-
     def email
       user.email
-    end
-
-    def display_email?
-      @display_name.nil?
     end
 
   private

--- a/lib/ama_layout/navigation.rb
+++ b/lib/ama_layout/navigation.rb
@@ -3,6 +3,7 @@ module AmaLayout
     include ActiveModel::Model
     include Draper::Decoratable
 
+    attr_writer :display_name
     attr_accessor :user, :current_url, :nav_file_path
 
     def initialize(args = {})
@@ -31,6 +32,18 @@ module AmaLayout
 
     def navigation_items
       YAML.load ERB.new(File.read nav_file_path).result
+    end
+
+    def display_name
+      @display_name && @display_name.titleize || email
+    end
+
+    def email
+      user.email
+    end
+
+    def display_email?
+      @display_name.nil?
     end
 
   private

--- a/spec/ama_layout/decorators/navigation_decorator_spec.rb
+++ b/spec/ama_layout/decorators/navigation_decorator_spec.rb
@@ -17,6 +17,43 @@ describe AmaLayout::NavigationDecorator do
     allow(Rails.configuration).to receive(:registries_site).and_return(registries_site)
   end
 
+  describe "#display_name_text" do
+    let(:user) { OpenStruct.new(email: 'john.doe@test.com') }
+
+    context "name is provided" do
+      let(:name) { "John D" }
+      let(:nav) { AmaLayout::Navigation.new(user: user, display_name: name).decorate }
+
+      it "has a welcome message" do
+        expect(nav.display_name_text).to eq "Welcome, John D"
+      end
+
+      context "long name given" do
+        let(:name) { "A Really Really Really Really Long Name" }
+
+        it "trucates to a total of 30 characters" do
+          expect(nav.display_name_text).to eq "Welcome, #{name.titleize}".truncate(30)
+        end
+      end
+    end
+
+    context "name is not provided" do
+      let(:nav) { AmaLayout::Navigation.new(user: user).decorate }
+
+      it "returns the user's email address" do
+        expect(nav.display_name_text).to eq user.email
+      end
+
+      context "a really long email" do
+        let(:user) { OpenStruct.new(email: 'areallyreallyreallylongemail@test.com') }
+
+        it "trucates to a total of 30 characters" do
+          expect(nav.display_name_text).to eq user.email.truncate(30)
+        end
+      end
+    end
+  end
+
   describe "#items" do
     before(:each) do
       allow_any_instance_of(AmaLayout::Navigation).to receive(:user).and_return(OpenStruct.new(navigation: "member"))

--- a/spec/ama_layout/navigation_spec.rb
+++ b/spec/ama_layout/navigation_spec.rb
@@ -35,37 +35,6 @@ describe AmaLayout::Navigation do
     end
   end
 
-  describe "#display_name" do
-    let(:email) { "test@test.com" }
-    let(:user) { OpenStruct.new(email: email) }
-
-    context "when a display name is set" do
-      let(:name) { 'Test' }
-      let(:subject) { described_class.new(user: user, display_name: name) }
-
-      it "returns a name" do
-        expect(subject.display_name).to eq name
-      end
-    end
-
-    context "with a lowercased name" do
-      let(:name) { 'bob p.' }
-      let(:subject) { described_class.new(user: user, display_name: name) }
-
-      it "titlizes the name" do
-        expect(subject.display_name).to eq name.titleize
-      end
-    end
-
-    context "display name is not set" do
-      let(:subject) { described_class.new(user: user) }
-
-      it "returns the user's email" do
-        expect(subject.display_name).to eq email
-      end
-    end
-  end
-
   describe "#items" do
     before(:each) do
       subject.user = OpenStruct.new navigation: "member"

--- a/spec/ama_layout/navigation_spec.rb
+++ b/spec/ama_layout/navigation_spec.rb
@@ -35,6 +35,37 @@ describe AmaLayout::Navigation do
     end
   end
 
+  describe "#display_name" do
+    let(:email) { "test@test.com" }
+    let(:user) { OpenStruct.new(email: email) }
+
+    context "when a display name is set" do
+      let(:name) { 'Test' }
+      let(:subject) { described_class.new(user: user, display_name: name) }
+
+      it "returns a name" do
+        expect(subject.display_name).to eq name
+      end
+    end
+
+    context "with a lowercased name" do
+      let(:name) { 'bob p.' }
+      let(:subject) { described_class.new(user: user, display_name: name) }
+
+      it "titlizes the name" do
+        expect(subject.display_name).to eq name.titleize
+      end
+    end
+
+    context "display name is not set" do
+      let(:subject) { described_class.new(user: user) }
+
+      it "returns the user's email" do
+        expect(subject.display_name).to eq email
+      end
+    end
+  end
+
   describe "#items" do
     before(:each) do
       subject.user = OpenStruct.new navigation: "member"


### PR DESCRIPTION
:elephant::art:

* Accept a `display_name` attribute for a navigation instance that will be displayed in the top navbar. If the name is nil, them the email address of the user is displayed. This content is truncated to 30 characters.