### PR TITLE
Fixex for flash messages

### DIFF
--- a/app/assets/stylesheets/ama_layout/layout_components/sections.scss
+++ b/app/assets/stylesheets/ama_layout/layout_components/sections.scss
@@ -171,7 +171,6 @@
 
 .page-container{
   @include grid-row;
-  margin-top: $top-bar-height;
   position: relative;
 }
 

--- a/app/assets/stylesheets/ama_layout/layout_components/siteheader.scss
+++ b/app/assets/stylesheets/ama_layout/layout_components/siteheader.scss
@@ -57,6 +57,10 @@
   /* overflow: auto; */
 }
 
+.top-nav-offset{
+  margin-top: $top-bar-height;
+}
+
 .title-bar{
   height: $top-bar-height;
 

--- a/app/views/ama_layout/_alert.html.erb
+++ b/app/views/ama_layout/_alert.html.erb
@@ -1,3 +1,5 @@
-<section class="section-centered--half">
-  <p class="error_notification"><%= flash[:alert].html_safe %></p>
-</section>
+<div class="row">
+  <div class="large-12">
+    <div class="error_notification"><span><%= flash[:alert].html_safe %></span></div>
+  </div>
+</div>

--- a/app/views/ama_layout/_notice.html.erb
+++ b/app/views/ama_layout/_notice.html.erb
@@ -1,3 +1,5 @@
-<section class="section-centered--half">
-  <p class="notice_notification"><%= flash[:notice].html_safe %></p>
-</section>
+<div class="row">
+  <div class="large-12">
+    <div class="notice_notification"><span><%= flash[:notice].html_safe %></span></div>
+  </div>
+</div>


### PR DESCRIPTION
🎨 
* Change the .page-container to remove the $top-bar-height because
a wrapper div was added to always be $top-bar-height distance from top
the season is because when the flash messages does not show there is not
markup render for it.