### PR TITLE
stretch --quarter elements

### DIFF
--- a/app/assets/stylesheets/ama_layout/layout_components/button-grouping.scss
+++ b/app/assets/stylesheets/ama_layout/layout_components/button-grouping.scss
@@ -18,7 +18,7 @@
 
     &--quarter{
       @include large-3;
-      @include small-6;
+      @include small-12;
     }
 
     &--third{


### PR DESCRIPTION
* stretches elements with --quarter the full width of the page on the
smallest (mobile) view

Turns this:
![screen shot 2016-07-20 at 14 26 29](https://cloud.githubusercontent.com/assets/547777/17001906/312a8f9e-4e86-11e6-8690-2bf419ea9372.png)

into this:
![screen shot 2016-07-20 at 14 26 09](https://cloud.githubusercontent.com/assets/547777/17001907/353fea34-4e86-11e6-9904-a39658f9e4a1.png)
