### PR TITLE
Fix Foundation Dependencies

### DIFF
--- a/app/assets/javascripts/ama_layout/desktop/foundation-custom.js
+++ b/app/assets/javascripts/ama_layout/desktop/foundation-custom.js
@@ -1,6 +1,7 @@
 //= require foundation.core.js
 //= require foundation.abide.js
 //= require foundation.accordion.js
+//= require foundation.drilldown.js
 //= require foundation.dropdown.js
 //= require foundation.dropdownMenu.js
 //= require foundation.equalizer.js


### PR DESCRIPTION
:elephant:
* We were using Foundation 6's drilldown menu in our layout.
* Without the javascript, the top menu would break when the window
  was resized - with a corresponding javascript console error.