### PR TITLE
Design Refresh - Breadcrumb Styles

### DIFF
--- a/app/assets/stylesheets/ama_layout/_settings.scss
+++ b/app/assets/stylesheets/ama_layout/_settings.scss
@@ -227,7 +227,7 @@ $breadcrumbs-item-color: $primary-color;
 $breadcrumbs-item-color-current: $black;
 $breadcrumbs-item-color-disabled: $medium-gray;
 $breadcrumbs-item-margin: 0.75rem;
-$breadcrumbs-item-uppercase: true;
+$breadcrumbs-item-uppercase: false;
 $breadcrumbs-item-slash: true;
 
 // 11. Button

--- a/app/assets/stylesheets/ama_layout/_settings.scss
+++ b/app/assets/stylesheets/ama_layout/_settings.scss
@@ -225,7 +225,7 @@ $breadcrumbs-margin: 0 0 $global-margin 0;
 $breadcrumbs-item-font-size: rem-calc(11);
 $breadcrumbs-item-color: $primary-color;
 $breadcrumbs-item-color-current: $black;
-$breadcrumbs-item-color-disabled: $medium-gray;
+$breadcrumbs-item-color-disabled: $stormcloud;
 $breadcrumbs-item-margin: 0.75rem;
 $breadcrumbs-item-uppercase: false;
 $breadcrumbs-item-slash: true;

--- a/app/assets/stylesheets/ama_layout/layout_components/breadcrumbs.scss
+++ b/app/assets/stylesheets/ama_layout/layout_components/breadcrumbs.scss
@@ -6,12 +6,14 @@
     font-size: 0.75rem;
   }
 
-  a.disabled{
-    pointer-events: none;
-    color: $stormcloud;
+  &__link{
+    &--disabled{
+      @extend .disabled;
+      pointer-events: none;
+    }
   }
 
-  li:not(:last-child)::after {
+  li:not(:last-child)::after{
     content: '>';
     top: 0;
     font-size: 125%;

--- a/app/assets/stylesheets/ama_layout/layout_components/breadcrumbs.scss
+++ b/app/assets/stylesheets/ama_layout/layout_components/breadcrumbs.scss
@@ -5,4 +5,16 @@
     display: inline-block;
     font-size: 0.75rem;
   }
+
+  a.disabled{
+    pointer-events: none;
+    color: $stormcloud;
+  }
+
+  li:not(:last-child)::after {
+    content: '>';
+    top: 0;
+    font-size: 125%;
+    color: $stormcloud;
+  }
 }


### PR DESCRIPTION
:art:
* Override Foundation's default breadcrumb separator of '/' to '>'.
* Add styles for the disabled breadcrumb state.

###### Screenshot

<img width="1584" alt="screen shot 2016-07-25 at 11 23 56 am" src="https://cloud.githubusercontent.com/assets/6474230/17110463/515e5354-525a-11e6-8f16-727bc7fd6209.png">
