### PR TITLE
adds margin-bottom to datetime selects

### DIFF
--- a/app/assets/stylesheets/ama_layout/layout_components/forms.scss
+++ b/app/assets/stylesheets/ama_layout/layout_components/forms.scss
@@ -227,8 +227,10 @@ input[type="checkbox"]{
   float: right;
 }
 
-.datetime.month, .datetime.day, .datetime.year{
-  margin-bottom: $base-margin;
+.datetime{
+  &.month, &.day, &.year{
+    margin-bottom: $base-margin;
+  }
 }
 
 /*-------------- Credit Card images ---------- */

--- a/app/assets/stylesheets/ama_layout/layout_components/forms.scss
+++ b/app/assets/stylesheets/ama_layout/layout_components/forms.scss
@@ -227,6 +227,10 @@ input[type="checkbox"]{
   float: right;
 }
 
+.datetime.month, .datetime.day, .datetime.year{
+  margin-bottom: $base-margin;
+}
+
 /*-------------- Credit Card images ---------- */
 .cc-type{
   width: 38px;


### PR DESCRIPTION
* SimpleForm generates 5 selects for a datetime object so it's easier to
style the first 3 inputs rather than creating a custom input in the apps
themselves
* for reference DateTime vs Date inputs:
  <select class="date optional month">
  <select class="datetime optional month">

Fixes the following:
![screen shot 2016-07-28 at 14 01 56](https://cloud.githubusercontent.com/assets/547777/17227669/a778d830-54cc-11e6-937f-8aac4cdefdb1.png)
