### PR TITLE
fixes nav highlighting bug when there is a query string in current url

### DIFF
--- a/lib/ama_layout/decorators/navigation_item_decorator.rb
+++ b/lib/ama_layout/decorators/navigation_item_decorator.rb
@@ -28,10 +28,8 @@ module AmaLayout
     end
 
     def current_url_without_query
-      uri = URI.parse(current_url)
-      uri.query = nil
-      uri.to_s
-    rescue URI::InvalidURIError => e
+      URI.parse(current_url).tap { |uri| uri.query = nil }.to_s
+    rescue URI::InvalidURIError
       current_url
     end
   end

--- a/lib/ama_layout/decorators/navigation_item_decorator.rb
+++ b/lib/ama_layout/decorators/navigation_item_decorator.rb
@@ -24,7 +24,15 @@ module AmaLayout
 
   private
     def active_link?
-      sub_nav.map(&:link).push(link).include? current_url
+      sub_nav.map(&:link).push(link).include? current_url_without_query
+    end
+
+    def current_url_without_query
+      uri = URI.parse(current_url)
+      uri.query = nil
+      uri.to_s
+    rescue URI::InvalidURIError => e
+      current_url
     end
   end
 end

--- a/spec/ama_layout/decorators/navigation_item_decorator_spec.rb
+++ b/spec/ama_layout/decorators/navigation_item_decorator_spec.rb
@@ -1,7 +1,7 @@
 describe AmaLayout::NavigationItemDecorator do
   let(:navigation_item) { FactoryGirl.build(:navigation_item) }
   let(:navigation_item_presenter) { navigation_item.decorate }
-  let(:items) { [{ text: "Othersite Overview", link: "othersite.com"}] }
+  let(:items) { [{ text: "Othersite Overview", link: "http://othersite.com"}] }
 
   describe "#sub_nav" do
     before(:each) do
@@ -68,9 +68,24 @@ describe AmaLayout::NavigationItemDecorator do
   end
 
   describe "#active_class" do
+    context "#current_url is an invalid URI" do
+      it "fails silently" do
+        navigation_item.current_url = "othersite.com"
+        navigation_item.sub_nav = items
+        expect(navigation_item_presenter.active_class).to eq nil
+      end
+    end
+
     context "with active_link" do
       it "return the class" do
-        navigation_item.current_url = "othersite.com"
+        navigation_item.current_url = "http://othersite.com"
+
+        navigation_item.sub_nav = items
+        expect(navigation_item_presenter.active_class).to eq "side-nav__child-link--active-page"
+      end
+
+      it "ignores query string parameters" do
+        navigation_item.current_url = "http://othersite.com?foo=bar"
         navigation_item.sub_nav = items
         expect(navigation_item_presenter.active_class).to eq "side-nav__child-link--active-page"
       end


### PR DESCRIPTION
* Google Analytics is appending query strings to the url, so the nav
isn't being highlighted properly
* This strips the query string before doing the match so both of the
following URLs highlight the same nav item:
http://registries.dev.ama.ab.ca/order/registrations/new?_ga=1.198935023.1769668054.1432918572
http://registries.dev.ama.ab.ca/order/registrations/new
* This could possibly break URLs where we use the query string to
distinguish but I'm going to assume that we are using RESTful routes and
am OK with breaking pages where we aren't

This example (with GA-appended query string) is broken (notice bottom nav item):
![screen shot 2016-08-02 at 14 56 56](https://cloud.githubusercontent.com/assets/547777/17345002/65434722-58c1-11e6-81da-6dbbbd483ac3.png)
This example (without GA-appended query string) is not broken (notice bottom nav item)
![screen shot 2016-08-02 at 14 56 42](https://cloud.githubusercontent.com/assets/547777/17345003/6574243c-58c1-11e6-9a0c-e7f6dba97c5e.png)

This PR makes the 2 URLs highlight the same nav item.