### PR TITLE
Sudo Mode - Foundation Modal

### DIFF
--- a/app/assets/stylesheets/ama_layout/_settings.scss
+++ b/app/assets/stylesheets/ama_layout/_settings.scss
@@ -456,7 +456,7 @@ $reveal-max-width: $global-width;
 $reveal-padding: 0;
 $reveal-border: 1px solid $medium-gray;
 $reveal-radius: $global-radius;
-$reveal-zindex: 1005;
+$reveal-zindex: 10000;
 $reveal-overlay-background: rgba($black, 0.45);
 
 // 29. Slider

--- a/app/assets/stylesheets/ama_layout/layout_components/buttons.scss
+++ b/app/assets/stylesheets/ama_layout/layout_components/buttons.scss
@@ -44,26 +44,6 @@
     }
   }
 
-  &--cancel{
-    @extend .button--de-emphasized;
-
-    // Expand buttons on medium down
-    @include breakpoint(medium down){
-      display: block;
-      margin: 0 auto;
-    }
-  }
-
-  &--confirm{
-    @extend .button;
-
-    // Expand buttons on medium down
-    @include breakpoint(medium down){
-      display: block;
-      margin: 0 auto;
-    }
-  }
-
   &--left{
     @extend .button;
     float: left;
@@ -82,6 +62,15 @@
   &--expand{
     @extend .button;
     @extend .expanded;
+  }
+
+  &--expand-medium-down{
+    @extend .button;
+
+    @include breakpoint(medium down){
+      display: block;
+      margin: 0 auto;
+    }
   }
 
   &--small{

--- a/app/assets/stylesheets/ama_layout/layout_components/buttons.scss
+++ b/app/assets/stylesheets/ama_layout/layout_components/buttons.scss
@@ -44,6 +44,26 @@
     }
   }
 
+  &--cancel{
+    @extend .button--de-emphasized;
+
+    // Expand buttons on medium down
+    @include breakpoint(medium down){
+      display: block;
+      margin: 0 auto;
+    }
+  }
+
+  &--confirm{
+    @extend .button;
+
+    // Expand buttons on medium down
+    @include breakpoint(medium down){
+      display: block;
+      margin: 0 auto;
+    }
+  }
+
   &--left{
     @extend .button;
     float: left;

--- a/lib/ama_layout/version.rb
+++ b/lib/ama_layout/version.rb
@@ -1,3 +1,3 @@
 module AmaLayout
-  VERSION = '4.4.1'
+  VERSION = '4.4.2'
 end


### PR DESCRIPTION
:art:

* Add the button--cancel and button--confirm classes for
  the reset password foundation modal in
  https://github.com/amaabca/gatekeeper/pull/648.
* The new classes will make the buttons expand on medium down.
* Bump version to 4.4.2.

###### Screenshots

(_Large_)
<img width="1453" alt="screen shot 2016-09-28 at 10 06 22 am" src="https://cloud.githubusercontent.com/assets/6474230/18921765/43da7f32-8563-11e6-93dc-8e9b1f7f35ce.png">

(_Medium_)
<img width="1004" alt="screen shot 2016-09-28 at 10 07 10 am" src="https://cloud.githubusercontent.com/assets/6474230/18921784/5717706e-8563-11e6-8bd8-a88ef23259a1.png">

(_Small_)
<img width="601" alt="screen shot 2016-09-28 at 10 07 37 am" src="https://cloud.githubusercontent.com/assets/6474230/18921806/6971b6de-8563-11e6-8594-52aefd751bbe.png">
