### PR TITLE
Add ribbon class to the radio-half rule

### DIFF
--- a/app/assets/stylesheets/ama_layout/layout_components/comparison-radios.scss
+++ b/app/assets/stylesheets/ama_layout/layout_components/comparison-radios.scss
@@ -11,6 +11,12 @@
 
   &__radio-half{
     @include medium-6;
+
+    &:nth-of-type(2){
+      .comparison-radios__ribbon{ //only display the ribbon for the first radio
+        display: none;
+      }
+    }
   }
 
   &__radio-third{

--- a/lib/ama_layout/version.rb
+++ b/lib/ama_layout/version.rb
@@ -1,3 +1,3 @@
 module AmaLayout
-  VERSION = '4.5.0'
+  VERSION = '4.5.1'
 end


### PR DESCRIPTION
🎨 
* BUG: https://ama-digital.myjetbrains.com/youtrack/issue/MEMBR-1371
* Because when using half there are only two radio buttons and the
ribbon is not filter from them showing it on both radio buttons. Added
a rule to hide it on the second one.