### PR TITLE
Fixing banner markup

### DIFF
--- a/app/assets/stylesheets/ama_layout/layout_components/banners.scss
+++ b/app/assets/stylesheets/ama_layout/layout_components/banners.scss
@@ -28,9 +28,14 @@
     @include clearfix;
   }
 
-  &__image{
+  &__image-container{
     @include large-2;
     @include small-12;
+  }
+
+  &__image{
+    display: block;
+    margin: 0 auto;
   }
 
   &__content-container{
@@ -39,7 +44,13 @@
   }
 
   &__content{
-      @include vertical-center;
+    position: relative;
+
+   &--vertical-center{    
+     @include breakpoint(large){
+       @include vertical-center;
+    }
+   }
   }
 
   &__link{

--- a/lib/ama_layout/version.rb
+++ b/lib/ama_layout/version.rb
@@ -1,3 +1,3 @@
 module AmaLayout
-  VERSION = '4.6.4'
+  VERSION = '4.6.5'
 end


### PR DESCRIPTION
:art:

Adding in a media query to ensure vertically aligned banners dont have absolute positioning on mobile. Made vertical align a modifier so it's not applied to base banner styles. 

Changed image classes so we can get the actual image tag to be centered inside it's parents div inside of applying classes only to it's container div. 
