### PR TITLE
Prevent displaying impossible days

### DIFF
--- a/ama_layout.gemspec
+++ b/ama_layout.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "foundation-rails", "~> 6.2.3.0"
+  spec.add_dependency "foundation-rails", "~> 6.2.4.0"
   spec.add_dependency "rails", "~> 4.2"
   spec.add_dependency "sass-rails", "~> 5.0"
-  spec.add_dependency "font-awesome-sass", "4.6.2"
+  spec.add_dependency "font-awesome-sass", "4.7.0"
   spec.add_dependency "draper", "~> 2.1"
   spec.add_dependency "browser", "~> 2.0"
   spec.add_dependency "breadcrumbs_on_rails", "~> 3.0.1"

--- a/app/assets/javascripts/ama_layout/desktop/index.js
+++ b/app/assets/javascripts/ama_layout/desktop/index.js
@@ -4,3 +4,4 @@
 //= require ./foundation-equalizer-reflow
 //= require ./cookie.ready
 //= require ../mailcheck/index
+//= require ../real_date_picker

--- a/app/assets/javascripts/ama_layout/real_date_picker.coffee
+++ b/app/assets/javascripts/ama_layout/real_date_picker.coffee
@@ -1,0 +1,35 @@
+class AMA.RealDatePicker
+  constructor: () ->
+    @setDefaultDays()
+    @addEvents()
+
+  setDefaultDays: () ->
+    @limitDaysInMonth $(dateContainer) for dateContainer in $('select.month').parents()
+
+  addEvents: () ->
+    $('select.month').on 'change', (event) =>
+      @limitDaysInMonth $(event.target).parent()
+
+    $('select.year').on 'change', (event) =>
+      @limitDaysInMonth $(event.target).parent()
+
+  limitDaysInMonth: (container) ->
+    year = container.find('.year').val()
+    month = container.find('.month').val()
+    daysInMonth = @daysInMonth(month, year)
+
+    if container.find('.day').val() > daysInMonth then @resetDay(container)
+
+    for day in [1..31]
+      option = container.find(".day option[value=#{day}]")
+      if day > daysInMonth then option.hide() else option.show()
+
+  daysInMonth: (month, year) ->
+    # JS months are 0-based, and day 0 is the last day of the previous month
+    new Date(year, month, 0).getDate()
+
+  resetDay: (container) ->
+    container.find('.day :nth-child(1)').prop('selected', true)
+
+$(document).ready ->
+  new AMA.RealDatePicker()

--- a/app/assets/javascripts/ama_layout/real_date_picker.coffee
+++ b/app/assets/javascripts/ama_layout/real_date_picker.coffee
@@ -1,4 +1,4 @@
-class AMA.RealDatePicker
+class AMALayout.RealDatePicker
   constructor: () ->
     @setDefaultDays()
     @addEvents()
@@ -32,4 +32,4 @@ class AMA.RealDatePicker
     container.find('.day :nth-child(1)').prop('selected', true)
 
 $(document).ready ->
-  new AMA.RealDatePicker()
+  new AMALayout.RealDatePicker()

--- a/app/assets/javascripts/ama_layout/real_date_picker.coffee
+++ b/app/assets/javascripts/ama_layout/real_date_picker.coffee
@@ -8,10 +8,10 @@ class AMALayout.RealDatePicker
 
   addEvents: () ->
     $('select.month').on 'change', (event) =>
-      @limitDaysInMonth $(event.target).parent()
+      @limitDaysInMonth $(event.currentTarget).parent()
 
     $('select.year').on 'change', (event) =>
-      @limitDaysInMonth $(event.target).parent()
+      @limitDaysInMonth $(event.currentTarget).parent()
 
   limitDaysInMonth: (container) ->
     year = container.find('.year').val()

--- a/lib/ama_layout/version.rb
+++ b/lib/ama_layout/version.rb
@@ -1,3 +1,3 @@
 module AmaLayout
-  VERSION = '4.6.5'
+  VERSION = '4.7.0'
 end

--- a/spec/ama_layout/fixtures/real_date_picker.html
+++ b/spec/ama_layout/fixtures/real_date_picker.html
@@ -1,0 +1,72 @@
+<div class="form-horizontal__input-wrapper">
+  <select id="birth_date_2i" name="birth_date(2i)" class="date optional month">
+    <option value="">Month</option>
+    <option value="1">January</option>
+    <option value="2">February</option>
+    <option value="3">March</option>
+    <option value="4">April</option>
+    <option value="5">May</option>
+    <option value="6">June</option>
+    <option value="7">July</option>
+    <option value="8">August</option>
+    <option value="9">September</option>
+    <option value="10">October</option>
+    <option value="11">November</option>
+    <option value="12">December</option>
+  </select>
+  <select id="birth_date_3i" name="birth_date(3i)" class="date optional day">
+    <option value="">Day</option>
+    <option value="1">1</option>
+    <option value="2">2</option>
+    <option value="3">3</option>
+    <option value="4">4</option>
+    <option value="5">5</option>
+    <option value="6">6</option>
+    <option value="7">7</option>
+    <option value="8">8</option>
+    <option value="9">9</option>
+    <option value="10">10</option>
+    <option value="11">11</option>
+    <option value="12">12</option>
+    <option value="13">13</option>
+    <option value="14">14</option>
+    <option value="15">15</option>
+    <option value="16">16</option>
+    <option value="17">17</option>
+    <option value="18">18</option>
+    <option value="19">19</option>
+    <option value="20">20</option>
+    <option value="21">21</option>
+    <option value="22">22</option>
+    <option value="23">23</option>
+    <option value="24">24</option>
+    <option value="25">25</option>
+    <option value="26">26</option>
+    <option value="27">27</option>
+    <option value="28">28</option>
+    <option value="29">29</option>
+    <option value="30">30</option>
+    <option value="31">31</option>
+  </select>
+  <select id="birth_date_1i" name="birth_date(1i)" class="date optional year">
+    <option value="">Year</option>
+    <option value="2000">2000</option>
+    <option value="1999">1999</option>
+    <option value="1998">1998</option>
+    <option value="1997">1997</option>
+    <option value="1996">1996</option>
+    <option value="1995">1995</option>
+    <option value="1994">1994</option>
+    <option value="1993">1993</option>
+    <option value="1992">1992</option>
+    <option value="1991">1991</option>
+    <option value="1990">1990</option>
+    <option value="1989">1989</option>
+    <option value="1988">1988</option>
+    <option value="1987">1987</option>
+    <option value="1986">1986</option>
+    <option value="1985">1985</option>
+    <option value="1984">1984</option>
+    <option value="1983">1983</option>
+  </select>
+</div>

--- a/spec/ama_layout/javascripts/real_date_picker_spec.coffee
+++ b/spec/ama_layout/javascripts/real_date_picker_spec.coffee
@@ -1,8 +1,8 @@
-describe "AMA.RealDatePicker", ->
+describe "AMALayout.RealDatePicker", ->
   beforeEach ->
     this.fixtures = fixture.load("real_date_picker.html", false)
     jasmine.Ajax.install()
-    new AMA.RealDatePicker()
+    new AMALayout.RealDatePicker()
 
   afterEach ->
     jasmine.Ajax.uninstall()

--- a/spec/ama_layout/real_date_picker_spec.coffee
+++ b/spec/ama_layout/real_date_picker_spec.coffee
@@ -1,0 +1,42 @@
+describe "AMA.RealDatePicker", ->
+  beforeEach ->
+    this.fixtures = fixture.load("real_date_picker.html", false)
+    jasmine.Ajax.install()
+    new AMA.RealDatePicker()
+
+  afterEach ->
+    jasmine.Ajax.uninstall()
+
+  describe "Initial state", ->
+    it "Displays 31 days", ->
+      available_days = $('select.day option')
+      expect(available_days.length).toBe 31 + 1
+
+  describe "Selecting a month with less than 31 days", ->
+    beforeEach ->
+      $('select.month').val(9)
+      $('select.month').trigger('change')
+
+    it "Displays 30 days", ->
+      available_days = $('select.day option').filter -> $(@).css("display") isnt "none"
+      expect(available_days.length).toBe 30 + 1
+
+  describe "Selecting February in a leap year", ->
+    beforeEach ->
+      $('select.year').val(2000)
+      $('select.month').val(2)
+      $('select.month').trigger('change')
+
+    it "Displays 29 days", ->
+      available_days = $('select.day option').filter -> $(@).css("display") isnt "none"
+      expect(available_days.length).toBe 29 + 1
+
+  describe "Changing month with an invalid day already selected", ->
+    beforeEach ->
+      $('select.day').val(31)
+
+    it "Resets day", ->
+      expect($('select.day option:selected').val()).toBe "31"
+      $('select.month').val(2)
+      $('select.month').trigger('change')
+      expect($('select.day option:selected').val()).toBe ""


### PR DESCRIPTION
- Rails default for date selects includes no dynamic behaviour, so all
  months/years have 31 days available to choose from.
- Selecting an invalid date (ex. February 31) will get rolled
  forward into the next month by the number of extra days (ex. March 3
  on a non-leap year) as soon as it gets cast into a Date type. This
  makes model validation impossible, and checking in the controller is
  dirty.
- This JS code will hide/show day options when the page loads and when month or
  year changes.

Bug raised here: https://ama-digital.myjetbrains.com/youtrack/issue/MEMBR-1387, but this behaviour should be applied to all applications using the default Rails date select inputs, so it's being implemented here.


Also including gem updates from here: https://github.com/amaabca/ama_layout/pull/160, to reduce number of times we have to update this gem across all apps.