### PR TITLE
Rails 5

### DIFF
--- a/ama_layout.gemspec
+++ b/ama_layout.gemspec
@@ -22,11 +22,16 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rails", ">= 4.2"
   spec.add_dependency "sass-rails", "~> 5.0"
   spec.add_dependency "font-awesome-sass", "4.7.0"
-  spec.add_dependency "draper", "3.0.0.pre1"
+  # Sigh ... SEE: https://github.com/drapergem/draper/issues/697
+  if Gem::Specification.find { |s| s.name == 'rails' }.version < Gem::Version.new('5.0.0')
+    spec.add_dependency "draper", "~> 2"
+  else
+    spec.add_dependency "draper", ">= 3.0.0.pre1"
+  end
   spec.add_dependency "browser", "~> 2.0"
   spec.add_dependency "breadcrumbs_on_rails", "~> 3.0.1"
   spec.add_development_dependency "bundler", "~> 1.11"
-  spec.add_development_dependency "rake", "~> 11.0"
+  spec.add_development_dependency "rake", ">= 11.0"
   spec.add_development_dependency "rspec-rails"
   spec.add_development_dependency "factory_girl"
   spec.add_development_dependency "simplecov"

--- a/ama_layout.gemspec
+++ b/ama_layout.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "foundation-rails", "~> 6.2.4.0"
-  spec.add_dependency "rails", "~> 4.2"
+  spec.add_dependency "rails", ">= 4.2"
   spec.add_dependency "sass-rails", "~> 5.0"
   spec.add_dependency "font-awesome-sass", "4.7.0"
   spec.add_dependency "draper", "~> 2.1"

--- a/ama_layout.gemspec
+++ b/ama_layout.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rails", ">= 4.2"
   spec.add_dependency "sass-rails", "~> 5.0"
   spec.add_dependency "font-awesome-sass", "4.7.0"
-  spec.add_dependency "draper", "~> 2.1"
+  spec.add_dependency "draper", ">= 2.1"
   spec.add_dependency "browser", "~> 2.0"
   spec.add_dependency "breadcrumbs_on_rails", "~> 3.0.1"
   spec.add_development_dependency "bundler", "~> 1.11"

--- a/lib/ama_layout/version.rb
+++ b/lib/ama_layout/version.rb
@@ -1,3 +1,3 @@
 module AmaLayout
-  VERSION = '4.8.6'
+  VERSION = '4.9.0'
 end


### PR DESCRIPTION
:elephant:

To upgrade our own applications to Rails 5, we need to relax the dependency on Rails in this gem.

* Add a homepage to the `.gemspec`.
* Allow for `rails` >= `4.2`.