### PR TITLE
Remove Pin and Win from nav

### DIFF
--- a/lib/ama_layout/navigation.yml
+++ b/lib/ama_layout/navigation.yml
@@ -50,9 +50,6 @@ member:
         link: "<%= Rails.configuration.registries_site %>/order/registrations/new"
   - text: "My Travel"
     link: "<%= Rails.configuration.travel_site %>"
-    sub_nav:
-      - text: "Pin & Win Contest"
-        link: "<%= Rails.configuration.travel_site %>/travel-promotions-contests/pin-and-win/dashboard"
   - text: "My Account Settings"
     link: "<%= Rails.configuration.gatekeeper_site %>/user/edit"
     icon: "fa-cogs"

--- a/lib/ama_layout/version.rb
+++ b/lib/ama_layout/version.rb
@@ -1,3 +1,3 @@
 module AmaLayout
-  VERSION = '5.0.2'
+  VERSION = '5.1.0'
 end


### PR DESCRIPTION
Addresses https://ama-digital.myjetbrains.com/youtrack/issue/TRAVL-7

Travel's Pin and Win contest is done. We've been asked to remove it from the left nav.

🐘 

TODO: I'll have to update the rails-5 branch with master after this is approved and merged. Gatekeeper uses that branch.