### PR TITLE
VSTS-438 - Fix Master Version

### DIFF
--- a/lib/ama_layout/version.rb
+++ b/lib/ama_layout/version.rb
@@ -1,3 +1,3 @@
 module AmaLayout
-  VERSION = '5.3.0'
+  VERSION = '5.4.0'
 end


### PR DESCRIPTION
:elephant:

* Version 5.3.0 was yanked on Rubygems, we are unable to push
  a proper 5.3.0 version because of this.
* Bump version

SEE: https://github.com/amaabca/ama_layout/pull/196