### PR TITLE
Rails 5 Version of zendesk help layout switch

### DIFF
--- a/app/helpers/ama_layout_path_helper.rb
+++ b/app/helpers/ama_layout_path_helper.rb
@@ -7,10 +7,6 @@ module AmaLayoutPathHelper
     "#{Rails.configuration.youraccount_site}/dashboard"
   end
 
-  def youraccount_help_path
-    "#{Rails.configuration.youraccount_site}/help"
-  end
-
   def youraccount_billing_path
     "#{Rails.configuration.youraccount_site}/billing"
   end

--- a/app/views/ama_layout/_siteheader.html.erb
+++ b/app/views/ama_layout/_siteheader.html.erb
@@ -15,7 +15,7 @@
       <ul class="menu" data-responsive-menu="drilldown medium-dropdown">
         <%= navigation.notifications %>
         <li>
-          <a href="<%= Rails.configuration.gatekeeper_site %>/help" target="_blank">Help</a>
+          <a href="https://albertamotorassociation.zendesk.com/hc/en-us" target="_blank">Help</a>
         </li>
         <li>
           <a href="<%= Rails.configuration.amaabca_site %>/membership/contact-us--centre-locations-hours-and-contact-information">Contact Us</a>
@@ -39,7 +39,7 @@
         <a class="side-nav__link" href="http://amaroadreports.ca/">AMA Road Reports</a>
       </li>
       <li class="side-nav__item">
-        <a class="side-nav__link" href="<%= Rails.configuration.gatekeeper_site %>/help" target="_blank">Help</a>
+        <a class="side-nav__link" href="https://albertamotorassociation.zendesk.com/hc/en-us" target="_blank">Help</a>
       </li>
       <li class="side-nav__item">
         <a class="side-nav__link" href="<%= Rails.configuration.amaabca_site %>/membership/contact-us--centre-locations-hours-and-contact-information">Contact Us</a>

--- a/lib/ama_layout/version.rb
+++ b/lib/ama_layout/version.rb
@@ -1,3 +1,3 @@
 module AmaLayout
-  VERSION = '6.8.0.pre'
+  VERSION = '6.9.0.pre'
 end

--- a/spec/helpers/ama_layout_path_helper_spec.rb
+++ b/spec/helpers/ama_layout_path_helper_spec.rb
@@ -27,12 +27,6 @@ describe AmaLayoutPathHelper do
     end
   end
 
-  describe "#youraccount_help_path" do
-    it "returns the help path" do
-      expect(helper.youraccount_help_path).to eq "#{youraccount_site}/help"
-    end
-  end
-
   describe "#youraccount_billing_path" do
     it "returns the billing path" do
       expect(helper.youraccount_billing_path).to eq "#{youraccount_site}/billing"


### PR DESCRIPTION
🐘 
* Required for gatekeeper (which is already rails 5)
* Change naviation link at top of page to go to zendesk
* Remove depricated helper
* https://amaabca.visualstudio.com/dx_technical_debt/_workitems?id=788&_a=edit

### PR Review Checklist
To be completed by the person who opens the PR. Use strikethroughs for items that are not applicable in list.
- [x] I have reviewed my own PR to check syntax & logic, removed unnecessary/old code, made sure everything aligns with our style guide and BEM.

~~ - [ ] I've added new components to the style guide (or have a PR in to add them). ~~

- [x] Any applicable version numbers have been updated.
- [x] I've tested on mobile, tablet, and desktop, as well as across all of the browsers we support.
- [x] I've proof-read all text for legibility, proper grammar, punctuation, and capitalization (titlecase).
- [x] I have written a detailed PR message explaining what is being changed and why
- [x] I’ve linked to any relevant VSTS tickets
- [x] I’ve added the appropriate review symbols to my PR - (elephant) for dev review, (art) for design
