### PR TITLE
Make ama_layout version rails 4-5 agnostic

### DIFF
--- a/ama_layout.gemspec
+++ b/ama_layout.gemspec
@@ -19,8 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'foundation-rails', '>= 6.4.1.2'
-  spec.add_dependency 'rails', '~> 4.2'
-  spec.add_dependency 'draper', '~> 2.1'
+  spec.add_dependency 'rails', '>= 4.2'
   spec.add_dependency 'browser', '~> 2.0'
   spec.add_dependency 'breadcrumbs_on_rails', '~> 3.0.1'
   spec.add_dependency 'redis-rails'

--- a/app/views/ama_layout/_sign_out_link.html.erb
+++ b/app/views/ama_layout/_sign_out_link.html.erb
@@ -1,0 +1,3 @@
+<li class="side-nav__item">
+  <a class="side-nav__link" href="/logout">Sign Out</a>
+</li>

--- a/lib/ama_layout.rb
+++ b/lib/ama_layout.rb
@@ -1,10 +1,10 @@
 require 'ama_layout/version'
 require 'rails/all'
 require 'foundation-rails'
-require 'draper'
 require 'browser'
 require 'breadcrumbs_on_rails'
 require 'redis-rails'
+require 'ama_layout/draper_replacement'
 require 'ama_layout/breadcrumb_builder'
 require 'ama_layout/moneris'
 require 'ama_layout/navigation'
@@ -25,6 +25,7 @@ require 'ama_layout/notifications'
 module AmaLayout
   class Engine < Rails::Engine
     initializer('ama_layout') do
+      Rails.configuration.view_paths = File.join(self.root, 'app', 'views')
       I18n.load_path << File.join(self.root, 'app', 'config', 'locales', 'en.yml')
       ::ActionController::Base.send :include, AmaLayout::ActionController
     end

--- a/lib/ama_layout/decorators/moneris_decorator.rb
+++ b/lib/ama_layout/decorators/moneris_decorator.rb
@@ -1,6 +1,7 @@
 module AmaLayout
-  class MonerisDecorator < Draper::Decorator
-    delegate_all
+  class MonerisDecorator
+    include AmaLayout::DraperReplacement
+    extend AmaLayout::DraperReplacement
 
     def textbox
       h.raw File.read textbox_style_file

--- a/lib/ama_layout/decorators/navigation_decorator.rb
+++ b/lib/ama_layout/decorators/navigation_decorator.rb
@@ -1,20 +1,19 @@
 module AmaLayout
-  class NavigationDecorator < Draper::Decorator
-    delegate_all
+  class NavigationDecorator
+    include AmaLayout::DraperReplacement
+    extend AmaLayout::DraperReplacement
 
     def items
       object.items.map { |i| i.decorate }
     end
 
     def display_name_text
-      name_or_email.truncate(30)
+      name_or_email.try(:truncate,30)
     end
 
     def sign_out_link
       return "" unless user
-      h.content_tag :li, class: "side-nav__item" do
-        h.concat h.link_to "Sign Out", "/logout", class: "side-nav__link"
-      end
+      h.render partial: "ama_layout/sign_out_link"
     end
 
     def top_nav

--- a/lib/ama_layout/decorators/navigation_item_decorator.rb
+++ b/lib/ama_layout/decorators/navigation_item_decorator.rb
@@ -1,6 +1,7 @@
 module AmaLayout
-  class NavigationItemDecorator < Draper::Decorator
-    delegate_all
+  class NavigationItemDecorator
+    include AmaLayout::DraperReplacement
+    extend AmaLayout::DraperReplacement
 
     def sub_nav
       object.sub_nav.map { |sn| sn.decorate }

--- a/lib/ama_layout/decorators/notification_decorator.rb
+++ b/lib/ama_layout/decorators/notification_decorator.rb
@@ -1,6 +1,7 @@
 module AmaLayout
-  class NotificationDecorator < Draper::Decorator
-    delegate_all
+  class NotificationDecorator
+    include AmaLayout::DraperReplacement
+    extend AmaLayout::DraperReplacement
 
     ICONS = {
       notice: {

--- a/lib/ama_layout/draper_replacement.rb
+++ b/lib/ama_layout/draper_replacement.rb
@@ -1,0 +1,27 @@
+module AmaLayout
+  module DraperReplacement
+    attr_accessor :object
+
+    def h
+      ActionView::Base.new(::ActionController::Base.view_paths, {}, ::ApplicationController.new)
+    end
+
+    def initialize(args = {})
+      self.object = args
+    end
+
+    def self.decorate_collection(objects = {})
+      objects.map { |o| self.new(o) }
+    end
+
+    def method_missing(method, *args, &block)
+      return super unless delegatable?(method)
+
+      (object || DraperReplacement).send(method, *args, &block)
+    end
+
+    def delegatable?(method)
+      object.respond_to?(method) || DraperReplacement.respond_to?(method)
+    end
+  end
+end

--- a/lib/ama_layout/moneris.rb
+++ b/lib/ama_layout/moneris.rb
@@ -1,7 +1,10 @@
 module AmaLayout
   class Moneris
     include ActiveModel::Model
-    include Draper::Decoratable
+
+    def decorate
+      AmaLayout::MonerisDecorator.new(self)
+    end
 
     attr_accessor :textbox_style_file
 

--- a/lib/ama_layout/navigation.rb
+++ b/lib/ama_layout/navigation.rb
@@ -1,7 +1,10 @@
 module AmaLayout
   class Navigation
     include ActiveModel::Model
-    include Draper::Decoratable
+
+    def decorate
+      AmaLayout::NavigationDecorator.new(self)
+    end
 
     attr_accessor :user, :current_url, :nav_file_path, :display_name
 

--- a/lib/ama_layout/navigation_item.rb
+++ b/lib/ama_layout/navigation_item.rb
@@ -1,7 +1,10 @@
 module AmaLayout
   class NavigationItem
     include ActiveModel::Model
-    include Draper::Decoratable
+
+    def decorate
+      AmaLayout::NavigationItemDecorator.new(self)
+    end
 
     attr_accessor :text, :icon, :link, :target, :alt, :sub_nav, :current_url
 

--- a/lib/ama_layout/notification.rb
+++ b/lib/ama_layout/notification.rb
@@ -1,7 +1,5 @@
 module AmaLayout
   class Notification
-    include Draper::Decoratable
-
     TYPES = %i[notice warning alert].freeze
     DEFAULT_LIFESPAN = 1.year.freeze
     FORMAT_VERSION = '1.0.0'.freeze

--- a/lib/ama_layout/version.rb
+++ b/lib/ama_layout/version.rb
@@ -1,3 +1,3 @@
 module AmaLayout
-  VERSION = '5.11.0'
+  VERSION = '5.12.0'
 end

--- a/lib/ama_layout/version.rb
+++ b/lib/ama_layout/version.rb
@@ -1,3 +1,3 @@
 module AmaLayout
-  VERSION = '5.12.0'
+  VERSION = '7.0.pre'
 end

--- a/spec/ama_layout/decorators/navigation_decorator_spec.rb
+++ b/spec/ama_layout/decorators/navigation_decorator_spec.rb
@@ -94,8 +94,9 @@ describe AmaLayout::NavigationDecorator do
     context "with items" do
       it "renders the partial" do
         allow_any_instance_of(AmaLayout::Navigation).to receive(:user).and_return(OpenStruct.new(navigation: "member"))
-        allow_any_instance_of(Draper::HelperProxy).to receive(:render).and_return "render"
-        expect(navigation_presenter.top_nav).to eq "render"
+        allow(Rails.configuration).to receive(:amaabca_site).and_return("amaabca.example.com")
+        allow(navigation_presenter).to receive(:sign_out_link).and_return("sign_out_link")
+        expect(navigation_presenter.top_nav).to include("AMA Road Reports", "http://auth.waffles.ca")
       end
     end
 
@@ -110,8 +111,7 @@ describe AmaLayout::NavigationDecorator do
     context "with items" do
       it "renders the partial" do
         allow_any_instance_of(AmaLayout::Navigation).to receive(:user).and_return(OpenStruct.new(navigation: "member"))
-        allow_any_instance_of(Draper::HelperProxy).to receive(:render).and_return "render"
-        expect(navigation_presenter.sidebar).to eq "render"
+        expect(navigation_presenter.sidebar).to include("Online Account", "Membership Overview", "Rewards Overview")
       end
     end
 
@@ -125,8 +125,7 @@ describe AmaLayout::NavigationDecorator do
   context "account toggle" do
     it "in ama_layout it renders a blank partial" do
       allow_any_instance_of(AmaLayout::Navigation).to receive(:user).and_return(OpenStruct.new(navigation: "member"))
-      allow_any_instance_of(Draper::HelperProxy).to receive(:render).and_return "render"
-      expect(navigation_presenter.account_toggle).to eq "render"
+      expect(navigation_presenter.account_toggle).to eq ""
     end
   end
 
@@ -153,8 +152,7 @@ describe AmaLayout::NavigationDecorator do
 
     describe '#notifications' do
       it 'renders the content to the page' do
-        expect(subject.h).to receive(:render).once.and_return true
-        expect(subject.notifications).to be true
+        expect(subject.notifications).to include("data-notifications-toggle")
       end
     end
 
@@ -217,8 +215,7 @@ describe AmaLayout::NavigationDecorator do
 
     describe '#notification_sidebar' do
       it 'renders content to the page' do
-        expect(subject.h).to receive(:render).once.and_return true
-        expect(subject.notification_sidebar).to be true
+        expect(subject.notification_sidebar).to include("Sign up now","off-canvas position-right")
       end
     end
 

--- a/spec/ama_layout/decorators/navigation_item_decorator_spec.rb
+++ b/spec/ama_layout/decorators/navigation_item_decorator_spec.rb
@@ -39,8 +39,7 @@ describe AmaLayout::NavigationItemDecorator do
     context "with items" do
       it "renders the partial" do
         navigation_item.sub_nav = items
-        allow_any_instance_of(Draper::HelperProxy).to receive(:render).and_return "render"
-        expect(navigation_item_presenter.top_sub_nav).to eq "render"
+        expect(navigation_item_presenter.top_sub_nav).to include("Othersite Overview", "http://othersite.com")
       end
     end
 
@@ -55,8 +54,7 @@ describe AmaLayout::NavigationItemDecorator do
     context "with items" do
       it "renders the partial" do
         navigation_item.sub_nav = items
-        allow_any_instance_of(Draper::HelperProxy).to receive(:render).and_return "render"
-        expect(navigation_item_presenter.sidebar_sub_nav).to eq "render"
+        expect(navigation_item_presenter.sidebar_sub_nav).to include(">Othersite Overview", "http://othersite.com")
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,8 +18,6 @@ ActionView::TestCase::TestController.instance_eval do
   helper Rails.application.routes.url_helpers
 end
 
-Draper::ViewContext.test_strategy :fast
-
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.include Rails.application.routes.url_helpers


### PR DESCRIPTION
🐘 
* Removed draper for ama_layout and replaced with custom bare-bones replacement
* Fixed tests that broke
* Loosened the restrictions on gems in gemspec
* parts of VSTS-1582 - https://amaabca.visualstudio.com/dx_technical_debt/_queries?id=1582&triage=false&_a=edit

### PR Review Checklist
To be completed by the person who opens the PR. Use strikethroughs for items that are not applicable in list.
- [x] Any applicable version numbers have been updated.
- [x] I've tested on mobile, tablet, and desktop, as well as across all of the browsers we support.
- [x] I've proof-read all text for legibility, proper grammar, punctuation, and capitalization (titlecase).
- [x] I have written a detailed PR message explaining what is being changed and why
- [x] I’ve linked to any relevant VSTS tickets
- [x] I’ve added the appropriate review symbols to my PR - (elephant) for dev review, (art) for design
