### PR TITLE
Fixed an issue with DraperReplacement.decorate_collection. 

### DIFF
--- a/lib/ama_layout/decorators/agent/navigation_decorator.rb
+++ b/lib/ama_layout/decorators/agent/navigation_decorator.rb
@@ -2,7 +2,6 @@ module AmaLayout
   module Agent
     class NavigationDecorator
       include AmaLayout::DraperReplacement
-      extend AmaLayout::DraperReplacement
 
       def items
         object.items.map(&:decorate)

--- a/lib/ama_layout/decorators/moneris_decorator.rb
+++ b/lib/ama_layout/decorators/moneris_decorator.rb
@@ -1,7 +1,6 @@
 module AmaLayout
   class MonerisDecorator
     include AmaLayout::DraperReplacement
-    extend AmaLayout::DraperReplacement
 
     def textbox
       h.raw File.read textbox_style_file

--- a/lib/ama_layout/decorators/navigation_decorator.rb
+++ b/lib/ama_layout/decorators/navigation_decorator.rb
@@ -1,7 +1,6 @@
 module AmaLayout
   class NavigationDecorator
     include AmaLayout::DraperReplacement
-    extend AmaLayout::DraperReplacement
 
     def items
       object.items.map { |i| i.decorate }

--- a/lib/ama_layout/decorators/navigation_item_decorator.rb
+++ b/lib/ama_layout/decorators/navigation_item_decorator.rb
@@ -1,7 +1,6 @@
 module AmaLayout
   class NavigationItemDecorator
     include AmaLayout::DraperReplacement
-    extend AmaLayout::DraperReplacement
 
     def sub_nav
       object.sub_nav.map { |sn| sn.decorate }

--- a/lib/ama_layout/decorators/notification_decorator.rb
+++ b/lib/ama_layout/decorators/notification_decorator.rb
@@ -1,7 +1,6 @@
 module AmaLayout
   class NotificationDecorator
     include AmaLayout::DraperReplacement
-    extend AmaLayout::DraperReplacement
 
     ICONS = {
       notice: {

--- a/lib/ama_layout/draper_replacement.rb
+++ b/lib/ama_layout/draper_replacement.rb
@@ -1,27 +1,31 @@
 module AmaLayout
   module DraperReplacement
-    attr_accessor :object, :controller
+    extend ActiveSupport::Concern
 
-    def h(view_data = {})
-      AmaLayoutView.new(view_data: view_data)
-    end
+    included do
+      attr_accessor :object, :controller
 
-    def initialize(args = {})
-      self.object = args
-    end
+      def h(view_data = {})
+        AmaLayoutView.new(view_data: view_data)
+      end
 
-    def self.decorate_collection(objects = {})
-      objects.map { |o| self.new(o) }
-    end
+      def initialize(args = {})
+        self.object = args
+      end
 
-    def method_missing(method, *args, &block)
-      return super unless delegatable?(method)
+      def method_missing(method, *args, &block)
+        return super unless delegatable?(method)
 
-      (object || DraperReplacement).send(method, *args, &block)
-    end
+        (object || DraperReplacement).send(method, *args, &block)
+      end
 
-    def delegatable?(method)
-      object.respond_to?(method) || DraperReplacement.respond_to?(method)
+      def delegatable?(method)
+        object.respond_to?(method) || DraperReplacement.respond_to?(method)
+      end
+
+      def self.decorate_collection(objects = {})
+        objects.map { |o| self.new(o) }
+      end
     end
   end
 end

--- a/spec/ama_layout/decorators/navigation_decorator_spec.rb
+++ b/spec/ama_layout/decorators/navigation_decorator_spec.rb
@@ -229,8 +229,16 @@ describe AmaLayout::NavigationDecorator do
     end
 
     describe '#notification_sidebar' do
+      before(:each) do
+        user.notifications.create(
+          type: :warning,
+          header: 'decorated_notification',
+          content: 'decorated_notification'
+        )
+      end
+
       it 'renders content to the page' do
-        expect(subject.notification_sidebar).to include("Sign up now","off-canvas position-right")
+        expect(subject.notification_sidebar).to include('decorated_notification')
       end
     end
 


### PR DESCRIPTION
It was a class method, but wasn't being included in the right context, so acted like a module method.

Convert the module to an ActiveSupport::Concern. Leverage ```included do``` to get the right class method context.
Updated the test so that we have coverage for the scenario.

:elephant:

### PR Review Checklist
To be completed by the person who opens the PR. Use strikethroughs for items that are not applicable in list.
- [x] I have reviewed my own PR to check syntax & logic, removed unnecessary/old code, made sure everything aligns with our style guide and BEM.
- [ ] ~~I've added new components to the style guide (or have a PR in to add them).~~
- [x] Any applicable version numbers have been updated.
- [ ] ~~I've tested on mobile, tablet, and desktop, as well as across all of the browsers we support.~~
- [x] I've proof-read all text for legibility, proper grammar, punctuation, and capitalization (titlecase).
- [x] I have written a detailed PR message explaining what is being changed and why
- [ ] ~~I’ve linked to any relevant VSTS tickets~~
- [x] I’ve added the appropriate review symbols to my PR - (elephant) for dev review, (art) for design
