### PR TITLE
VSTS-2710 - Fix Top Nav Bar

### DIFF
--- a/lib/ama_layout/decorators/navigation_decorator.rb
+++ b/lib/ama_layout/decorators/navigation_decorator.rb
@@ -3,11 +3,11 @@ module AmaLayout
     include AmaLayout::DraperReplacement
 
     def items
-      object.items.map { |i| i.decorate }
+      object.items.map(&:decorate)
     end
 
     def display_name_text
-      name_or_email.try(:truncate,30)
+      name_or_email.try(:truncate, 30)
     end
 
     def sign_out_link
@@ -16,7 +16,7 @@ module AmaLayout
     end
 
     def top_nav
-      h.render partial: "ama_layout/top_nav", locals: { navigation: self } if items.any?
+      h.render partial: "ama_layout/top_nav", locals: { navigation: self } if user
     end
 
     def sidebar

--- a/lib/ama_layout/version.rb
+++ b/lib/ama_layout/version.rb
@@ -1,3 +1,3 @@
 module AmaLayout
-  VERSION = '8.0.1'
+  VERSION = '8.0.2'
 end


### PR DESCRIPTION
:elephant:

* Previously we were only displaying a custom top navigation bar
  if there were any sidebar navigation items present. Unfortunately,
  if we move away from using the navigation items in this gem, this
  condition is no longer true.
* Instead, show a custom top bar if the user is present.

SEE: https://amaabca.visualstudio.com/travel_backlog/_workitems?id=2710

### PR Review Checklist
To be completed by the person who opens the PR. Use strikethroughs for items that are not applicable in list.
- [X] I have reviewed my own PR to check syntax & logic, removed unnecessary/old code, made sure everything aligns with our style guide and BEM.
- ~I've added new components to the style guide (or have a PR in to add them).~
- [X] Any applicable version numbers have been updated.
- [X] I've tested on mobile, tablet, and desktop, as well as across all of the browsers we support.
- [X] I've proof-read all text for legibility, proper grammar, punctuation, and capitalization (titlecase).
- [X] I have written a detailed PR message explaining what is being changed and why
- [X] I’ve linked to any relevant VSTS tickets
- [X] I’ve added the appropriate review symbols to my PR - (elephant) for dev review, (art) for design
