### PR TITLE
VSTS-2710 - API Driven Navigation

### DIFF
--- a/app/views/ama_layout/_mobile_links.html.erb
+++ b/app/views/ama_layout/_mobile_links.html.erb
@@ -1,0 +1,22 @@
+<div class="off-canvas position-left" id="offCanvasLeft" data-off-canvas>
+  <h2 class="side-nav__header">Online Account</h2>
+  <div class="side-nav__content">
+    <ul class="side-nav__list">
+      <li class="side-nav__item">
+        <%= link_to 'Sign In', "#{Rails.configuration.gatekeeper_site}/login", class: 'side-nav__link' %>
+      </li>
+      <li class="side-nav__item">
+        <a class="side-nav__link" href="<%= Rails.configuration.amaabca_site %>">AMA Website</a>
+      </li>
+      <li class="side-nav__item">
+        <a class="side-nav__link" href="http://amaroadreports.ca/">AMA Road Reports</a>
+      </li>
+      <li class="side-nav__item">
+        <a class="side-nav__link" href="https://albertamotorassociation.zendesk.com/hc/en-us" target="_blank">Help</a>
+      </li>
+      <li class="side-nav__item">
+        <a class="side-nav__link" href="<%= Rails.configuration.amaabca_site %>/membership/contact-us--centre-locations-hours-and-contact-information">Contact Us</a>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/app/views/ama_layout/_siteheader.html.erb
+++ b/app/views/ama_layout/_siteheader.html.erb
@@ -23,28 +23,7 @@
     </div>
   </div>
 </div>
-<div class="off-canvas position-left" id="offCanvasLeft" data-off-canvas>
-  <h2 class="side-nav__header">Online Account</h2>
-  <div class="side-nav__content">
-    <ul class="side-nav__list">
-      <%= navigation.account_toggle(self) %>
-      <%= render partial: "ama_layout/main_nav_item", collection: navigation.items, as: :nav_item %>
-      <li class="side-nav__item">
-        <a class="side-nav__link" href="<%= Rails.configuration.amaabca_site %>">AMA Website</a>
-      </li>
-      <li class="side-nav__item">
-        <a class="side-nav__link" href="http://amaroadreports.ca/">AMA Road Reports</a>
-      </li>
-      <li class="side-nav__item">
-        <a class="side-nav__link" href="https://albertamotorassociation.zendesk.com/hc/en-us" target="_blank">Help</a>
-      </li>
-      <li class="side-nav__item">
-        <a class="side-nav__link" href="<%= Rails.configuration.amaabca_site %>/membership/contact-us--centre-locations-hours-and-contact-information">Contact Us</a>
-      </li>
-      <%= navigation.sign_out_link %>
-    </ul>
-  </div>
-</div>
+<%= navigation.mobile_links %>
 <%= navigation.notification_sidebar %>
 <div class="javascript_errors error_notification" hidden></div>
 <noscript>

--- a/lib/ama_layout/decorators/navigation_decorator.rb
+++ b/lib/ama_layout/decorators/navigation_decorator.rb
@@ -43,6 +43,10 @@ module AmaLayout
       end
     end
 
+    def mobile_links
+      h.render 'ama_layout/mobile_links' unless user
+    end
+
     def notification_badge
       if new_notifications?
         h.content_tag(

--- a/lib/ama_layout/version.rb
+++ b/lib/ama_layout/version.rb
@@ -1,3 +1,3 @@
 module AmaLayout
-  VERSION = '8.0.2'
+  VERSION = '9.0.0'
 end

--- a/spec/ama_layout/decorators/navigation_decorator_spec.rb
+++ b/spec/ama_layout/decorators/navigation_decorator_spec.rb
@@ -1,26 +1,18 @@
 describe AmaLayout::NavigationDecorator do
   let(:navigation) { FactoryGirl.build(:navigation) }
   let(:navigation_presenter) { navigation.decorate }
-  let(:gatekeeper_site) { "http://auth.waffles.ca" }
-  let(:youraccount_site) { "http://youraccount.waffles.ca" }
-  let(:insurance_site) { "http://insurance.waffles.ca" }
-  let(:membership_site) { "http://membership.waffles.ca" }
-  let(:driveredonline_site) { "http://driveredonline.waffles.ca" }
-  let(:registries_site) { "http://registries.waffles.ca" }
-  let(:automotive_site) { "http://automotive.waffles.ca" }
-  let(:travel_site) { "http://travel.waffles.ca" }
-  let(:travel_login_url) { "http://travel.waffles.ca/MyAccount" }
 
   before(:each) do
-    allow(Rails.configuration).to receive(:gatekeeper_site).and_return(gatekeeper_site)
-    allow(Rails.configuration).to receive(:youraccount_site).and_return(youraccount_site)
-    allow(Rails.configuration).to receive(:insurance_site).and_return(insurance_site)
-    allow(Rails.configuration).to receive(:membership_site).and_return(membership_site)
-    allow(Rails.configuration).to receive(:driveredonline_site).and_return(driveredonline_site)
-    allow(Rails.configuration).to receive(:registries_site).and_return(registries_site)
-    allow(Rails.configuration).to receive(:automotive_site).and_return(automotive_site)
-    allow(Rails.configuration).to receive(:travel_site).and_return(travel_site)
-    allow(Rails.configuration).to receive(:travel_login_url).and_return(travel_login_url)
+    Rails.configuration.gatekeeper_site = 'http://auth.waffles.ca'
+    Rails.configuration.youraccount_site = 'http://youraccount.waffles.ca'
+    Rails.configuration.insurance_site = 'http://insurance.waffles.ca'
+    Rails.configuration.membership_site = 'http://membership.waffles.ca'
+    Rails.configuration.driveredonline_site = 'http://driveredonline.waffles.ca'
+    Rails.configuration.registries_site = 'http://registries.waffles.ca'
+    Rails.configuration.automotive_site = 'http://automotive.waffles.ca'
+    Rails.configuration.travel_site = 'http://travel.waffles.ca'
+    Rails.configuration.travel_login_url = 'http://travel.waffles.ca/MyAccount'
+    Rails.configuration.amaabca_site = 'http://test.ama.ab.ca/'
   end
 
   describe "#display_name_text" do
@@ -73,6 +65,24 @@ describe AmaLayout::NavigationDecorator do
       items = navigation_presenter.items
       items.each do |i|
         expect(i).to be_a AmaLayout::NavigationItemDecorator
+      end
+    end
+  end
+
+  describe '#mobile_links' do
+    context 'with user' do
+      before(:each) do
+        navigation_presenter.object = OpenStruct.new(user: true)
+      end
+
+      it 'returns nil' do
+        expect(navigation_presenter.mobile_links).to be_nil
+      end
+    end
+
+    context 'without user' do
+      it 'renders an offcanvas menu' do
+        expect(navigation_presenter.mobile_links).to include('off-canvas')
       end
     end
   end


### PR DESCRIPTION
:elephant: :art:

* Make a breaking change to the `siteheader` partial. This change
  removes the duplication of our navugation menu for the mobile
  off canvas element. Instead, this markup will be rendered from
  our API calls.
* To retain existing functionality, add a small offcanvas element
  when the user is not logged in. This will collapse a basic menu
  to the user on mobile.
* Fix rails configuration stubbing in tests. Instead, set the actual
  configuration values.
* Bump the major version - this is a breaking change.

SEE: https://amaabca.visualstudio.com/travel_backlog/_workitems?id=2710

### PR Review Checklist
To be completed by the person who opens the PR. Use strikethroughs for items that are not applicable in list.
- [X] I have reviewed my own PR to check syntax & logic, removed unnecessary/old code, made sure everything aligns with our style guide and BEM.
- ~I've added new components to the style guide (or have a PR in to add them).~
- [X] Any applicable version numbers have been updated.
- [X] I've tested on mobile, tablet, and desktop, as well as across all of the browsers we support.
- [X] I've proof-read all text for legibility, proper grammar, punctuation, and capitalization (titlecase).
- [X] I have written a detailed PR message explaining what is being changed and why
- [X] I’ve linked to any relevant VSTS tickets
- [X] I’ve added the appropriate review symbols to my PR - (elephant) for dev review, (art) for design
