### PR TITLE
Make mobile links match

### DIFF
--- a/app/views/ama_layout/agent/_siteheader.html.erb
+++ b/app/views/ama_layout/agent/_siteheader.html.erb
@@ -17,15 +17,6 @@
     </div>
   </div>
 </div>
-<div class="off-canvas position-left" id="offCanvasLeft" data-off-canvas>
-  <h2 class="side-nav__header">Online Account</h2>
-  <div class="side-nav__content">
-    <ul class="side-nav__list">
-      <%= render partial: "ama_layout/main_nav_item", collection: navigation.items, as: :nav_item %>
-      <%= navigation.sign_out_link %>
-    </ul>
-  </div>
-</div>
 <div class="javascript_errors error_notification" hidden></div>
 <noscript>
   <div class="mt1 large-12 columns text-center error_notification">

--- a/lib/ama_layout/version.rb
+++ b/lib/ama_layout/version.rb
@@ -1,3 +1,3 @@
 module AmaLayout
-  VERSION = '9.2.0'
+  VERSION = '9.3.0'
 end


### PR DESCRIPTION
* Removing this code points the mobile nav to api instead
* The offCanvasLeft id exists in the api markup, but the local copy i'm removing here overrides it

VSTS 6881 - https://amaabca.visualstudio.com/driver_education_backlog/_workitems/edit/6881

### PR Review Checklist
To be completed by the person who opens the PR. Use strikethroughs for items that are not applicable in list.
- [x] I have reviewed my own PR to check syntax & logic, removed unnecessary/old code, made sure everything aligns with our style guide and BEM.
- [x] Any applicable version numbers have been updated.
- [x] I've tested on mobile, tablet, and desktop, as well as across all of the browsers we support.
- [x] I've proof-read all text for legibility, proper grammar, punctuation, and capitalization (titlecase).
- [x] I have written a detailed PR message explaining what is being changed and why
- [x] I’ve linked to any relevant VSTS tickets
- [x] I’ve added the appropriate review symbols to my PR - (elephant) for dev review, (art) for design
