### PR TITLE
Update Foundation Rails

### DIFF
--- a/ama_layout.gemspec
+++ b/ama_layout.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'foundation-rails', '>= 6.4.1.2'
+  spec.add_dependency 'foundation-rails', '>= 6.4.3.0'
   spec.add_dependency 'rails', '>= 4.2'
   spec.add_dependency 'browser', '~> 2.0'
   spec.add_dependency 'breadcrumbs_on_rails', '>= 3'

--- a/app/assets/javascripts/ama_layout/desktop/foundation-custom.js
+++ b/app/assets/javascripts/ama_layout/desktop/foundation-custom.js
@@ -6,7 +6,6 @@
 //= require foundation.util.motion.js
 //= require foundation.util.nest.js
 //= require foundation.util.timer.js
-//= require foundation.util.timerAndImageLoader.js
 //= require foundation.util.triggers.js
 //= require foundation.abide.js
 //= require foundation.accordion.js

--- a/lib/ama_layout/version.rb
+++ b/lib/ama_layout/version.rb
@@ -1,3 +1,3 @@
 module AmaLayout
-  VERSION = '9.3.0'
+  VERSION = '9.4.0'
 end


### PR DESCRIPTION
:elephant:
:art:

* Remove the `util.timerAndImageLoader` reference in our custom
  foundation javascript includes because it is no longer present
  upstream.
* Bump `foundation-rails` version to require `6.4.3.0` or higher.
* This will bump our Foundation version from `6.4.1` to `6.4.3`.
  The changes that requires migration between these are to the
  xy-grid, which we do not currently use.

SEE: https://github.com/zurb/foundation-sites/releases/tag/v6.4.2
SEE: https://github.com/zurb/foundation-rails/pull/251

### PR Review Checklist
To be completed by the person who opens the PR. Use strikethroughs for items that are not applicable in list.
- [X] I have reviewed my own PR to check syntax & logic, removed unnecessary/old code, made sure everything aligns with our style guide and BEM.
- [X] I've added new components to the style guide (or have a PR in to add them).
- [X] Any applicable version numbers have been updated.
- [X] I've tested on mobile, tablet, and desktop, as well as across all of the browsers we support.
- [X] I've proof-read all text for legibility, proper grammar, punctuation, and capitalization (titlecase).
- [X] I have written a detailed PR message explaining what is being changed and why
- [X] I’ve linked to any relevant VSTS tickets
- [X] I’ve added the appropriate review symbols to my PR - (elephant) for dev review, (art) for design
