### PR TITLE
VSTS-10616 - Confirm Modal

### DIFF
--- a/app/assets/javascripts/ama_layout/confirm_modal.js
+++ b/app/assets/javascripts/ama_layout/confirm_modal.js
@@ -17,7 +17,12 @@ $.rails.allowAction = function(link){
 */
 $.rails.confirmed = function(link){
   link.data('confirm', null);
-  link.trigger('click.rails');
+  if (link.data('method')){
+    // let rails handle non-GET requests
+    // (i.e. data-method="delete")
+    return link.trigger('click.rails');
+  }
+  window.location.href = link.attr('href');
 }
 
 /*

--- a/lib/ama_layout/version.rb
+++ b/lib/ama_layout/version.rb
@@ -1,3 +1,3 @@
 module AmaLayout
-  VERSION = '9.4.0'
+  VERSION = '9.4.1'
 end


### PR DESCRIPTION
🐘

* Our `confirm_modal` javascript file changed the
  rails jquery_ujs handler functions to render a foundation modal
  for any rails `data-confirm` links.
* Previously these overrides only worked when the element containing
  the `data-confirm` attribute also submitted a form using rails ajax
  `i.e. data-method="delete"`.
* Implement a check that looks for the `data-method` on the element.
  When true, we should let rails handle the ajax call as usual. When
  false, we should assume that the link is a GET request and we should
  redirect the browser.

SEE: https://amaabca.visualstudio.com/POS%20-%20Enhancements/_workitems/edit/10616

### PR Review Checklist
To be completed by the person who opens the PR. Use strikethroughs for items that are not applicable in list.
- [X] I have reviewed my own PR to check syntax & logic, removed unnecessary/old code, made sure everything aligns with our style guide and BEM.
- ~[ ] I've added new components to the style guide (or have a PR in to add them).~
- [X] Any applicable version numbers have been updated.
- [X] I've tested on mobile, tablet, and desktop, as well as across all of the browsers we support.
- [X] I've proof-read all text for legibility, proper grammar, punctuation, and capitalization (titlecase).
- [X] I have written a detailed PR message explaining what is being changed and why
- [X] I’ve linked to any relevant VSTS tickets
- [X] I’ve added the appropriate review symbols to my PR - (elephant) for dev review, (art) for design