### PR TITLE
VSTS-10616 - Confirmation Modal

### DIFF
--- a/app/assets/javascripts/ama_layout/confirm_modal.js
+++ b/app/assets/javascripts/ama_layout/confirm_modal.js
@@ -32,11 +32,11 @@ $.rails.confirmed = function(link) {
 $.rails.showConfirmationDialog = function(link) {
   var el = link.data('confirm');
   var modal = $('[data-' + el + ']');
-  modal.foundation('open');
   var key = link.data('reveal-confirm-key');
   if (key && key.length) {
     modal.data('reveal-confirm-key', key);
   }
+  modal.foundation('open');
 }
 
 /*
@@ -67,15 +67,13 @@ $.rails.showConfirmationDialog = function(link) {
 */
 $(document).on('click', '*[data-reveal-confirm]', function(e) {
   e.preventDefault();
-  var link;
   var target = e.currentTarget;
   var el = $(target).data('reveal-confirm');
   var modal = $('[data-' + el + ']');
   var key = $(modal).data('reveal-confirm-key');
+  var link = $('[data-confirm="'+ el + '"]');
   if (key && key.length) {
     link = $('[data-reveal-confirm-key=' + key + ']');
-  } else {
-    link = $('[data-confirm="'+ el + '"]');
   }
   $(modal).foundation('close');
   $(modal).data('reveal-confirm-key', null);

--- a/app/assets/javascripts/ama_layout/confirm_modal.js
+++ b/app/assets/javascripts/ama_layout/confirm_modal.js
@@ -2,8 +2,8 @@
   Override the default confirm dialog
   defined by jQuery UJS
 */
-$.rails.allowAction = function(link){
-  if (link.data('confirm') == undefined){
+$.rails.allowAction = function(link) {
+  if (link.data('confirm') == undefined) {
     return true;
   }
   $.rails.showConfirmationDialog(link);
@@ -15,7 +15,7 @@ $.rails.allowAction = function(link){
   Rails doesn't re-trigger the modal. Then
   trigger a click of the link.
 */
-$.rails.confirmed = function(link){
+$.rails.confirmed = function(link) {
   link.data('confirm', null);
   if (link.data('method')){
     // let rails handle non-GET requests
@@ -29,13 +29,19 @@ $.rails.confirmed = function(link){
   Toggle the Foundation reveal modal when a data-confirm
   element is clicked.
 */
-$.rails.showConfirmationDialog = function(link){
+$.rails.showConfirmationDialog = function(link) {
   var el = link.data('confirm');
-  $('[data-' + el + ']').foundation('open');
+  var modal = $('[data-' + el + ']');
+  modal.foundation('open');
+  var key = link.data('reveal-confirm-key');
+  if (key && key.length) {
+    modal.data('reveal-confirm-key', key);
+  }
 }
 
 /*
-  General Usage:
+  Single Link/Single Modal:
+
   Link
   <a href="somewhere" data-confirm="my-data-element">Delete</a>
 
@@ -45,12 +51,33 @@ $.rails.showConfirmationDialog = function(link){
     <a href="#" data-reveal-confirm="my-data-element">OK</a>
     ...
   </div>
+
+  Multiple Links/Single Modal:
+
+  Links
+  <a href="somewhere" data-confirm="my-data-element" data-reveal-confirm-key="element-1">Delete</a>
+  <a href="somewhere-else" data-confirm="my-data-element" data-reveal-confirm-key="element-2">Delete</a>
+
+  Modal
+  <div class="reveal" data-reveal data-my-data-element>
+    ...
+    <a href="#" data-reveal-confirm="my-data-element">OK</a>
+    ...
+  </div>
 */
-$(document).on('click', '*[data-reveal-confirm]', function(e){
+$(document).on('click', '*[data-reveal-confirm]', function(e) {
   e.preventDefault();
-  var el = $(e.currentTarget).data('reveal-confirm');
-  var link = $('[data-confirm="'+ el + '"]');
+  var link;
+  var target = e.currentTarget;
+  var el = $(target).data('reveal-confirm');
   var modal = $('[data-' + el + ']');
+  var key = $(modal).data('reveal-confirm-key');
+  if (key && key.length) {
+    link = $('[data-reveal-confirm-key=' + key + ']');
+  } else {
+    link = $('[data-confirm="'+ el + '"]');
+  }
   $(modal).foundation('close');
+  $(modal).data('reveal-confirm-key', null);
   $.rails.confirmed(link);
 });

--- a/lib/ama_layout/version.rb
+++ b/lib/ama_layout/version.rb
@@ -1,3 +1,3 @@
 module AmaLayout
-  VERSION = '9.4.1'
+  VERSION = '9.5.0'
 end


### PR DESCRIPTION
:elephant:

* We need to be able to have a single confirm modal element
  share potentially many trigger links (i.e. many links can trigger
  the same confirmation modal).
* To achieve this, we must define a unique relationship between
  a modal and a given link.
* Allow an optional `data-reveal-confirm-key` on links that trigger
  confirmation modals. This key is temporarily written to the modal
  element when it is opened as metadata. This way, the modal element
  always contains information about which link triggered it to open.
* Using the metadata above, we can correctly redirect to the proper
  action when the modal is confirmed.

SEE: https://amaabca.visualstudio.com/POS%20-%20Enhancements/_workitems/edit/10616

### PR Review Checklist
To be completed by the person who opens the PR. Use strikethroughs for items that are not applicable in list.
- [X] I have reviewed my own PR to check syntax & logic, removed unnecessary/old code, made sure everything aligns with our style guide and BEM.
- ~[ ] I've added new components to the style guide (or have a PR in to add them).~
- [X] Any applicable version numbers have been updated.
- [X] I've tested on mobile, tablet, and desktop, as well as across all of the browsers we support.
- [X] I've proof-read all text for legibility, proper grammar, punctuation, and capitalization (titlecase).
- [X] I have written a detailed PR message explaining what is being changed and why
- [X] I’ve linked to any relevant VSTS tickets
- [X] I’ve added the appropriate review symbols to my PR - (elephant) for dev review, (art) for design
