### PR TITLE
Add a guard for the link on modals

### DIFF
--- a/app/assets/javascripts/ama_layout/confirm_modal.js
+++ b/app/assets/javascripts/ama_layout/confirm_modal.js
@@ -22,7 +22,9 @@ $.rails.confirmed = function(link) {
     // (i.e. data-method="delete")
     return link.trigger('click.rails');
   }
-  window.location.href = link.attr('href');
+  if (link.attr('href')) {
+    window.location.href = link.attr('href');
+  }
 }
 
 /*

--- a/lib/ama_layout/version.rb
+++ b/lib/ama_layout/version.rb
@@ -1,3 +1,3 @@
 module AmaLayout
-  VERSION = '9.5.0'
+  VERSION = '9.5.1'
 end


### PR DESCRIPTION
* When updating gems insurance is triggering a modal using a dropdown on
change event which does not have a link prop and causes a redirect to
undefined. Add a condition to redirect only if the link is present.
* [VSTS_12433](https://amaabca.visualstudio.com/dx_technical_debt/_workitems/edit/12433)
🐘 