### PR TITLE
ADO-19604 - Support

### DIFF
--- a/app/assets/javascripts/ama_layout/mailcheck/email_suggestion.coffee
+++ b/app/assets/javascripts/ama_layout/mailcheck/email_suggestion.coffee
@@ -54,20 +54,26 @@ class AMALayout.EmailSuggestion
         domains: @domains
         secondLevelDomains: @secondLevelDomains
         suggested: (element, suggestion) =>
+          event = new Event('mailcheck');
           text = @suggestionMarkup suggestion.address, suggestion.domain
           if !$('.email_hint').length
-            $("<div class='email_hint'>#{text}</div>").insertAfter(element).fadeIn 150
+            $("<div class='email_hint'>#{text}</div>").insertAfter(element).show()
           else
             $('.email_hint').html text
+          window.dispatchEvent(event)
         empty: (element) ->
+          event = new Event('mailcheck');
           $('.email_hint').html ''
+          window.dispatchEvent(event)
 
     $(document).on 'click', '.email_hint .suggestion a.email_domain', (e) =>
       @trackUsage()
+      event = new Event('mailcheck');
       email_hint = $(e.originalEvent.target).parents('.email_hint')
       email = $(email_hint).prevAll('input[type=email]:last')
       $(email).val $('.suggestion').first().text()
       $('.email_hint').remove()
+      window.dispatchEvent(event)
 
   suggestionMarkup: (address, domain) ->
     "Did you mean " +

--- a/app/assets/javascripts/ama_layout/mailcheck/email_suggestion.coffee
+++ b/app/assets/javascripts/ama_layout/mailcheck/email_suggestion.coffee
@@ -54,7 +54,7 @@ class AMALayout.EmailSuggestion
         domains: @domains
         secondLevelDomains: @secondLevelDomains
         suggested: (element, suggestion) =>
-          event = new Event('mailcheck');
+          event = @buildEvent()
           text = @suggestionMarkup suggestion.address, suggestion.domain
           if !$('.email_hint').length
             $("<div class='email_hint'>#{text}</div>").insertAfter(element).show()
@@ -62,18 +62,24 @@ class AMALayout.EmailSuggestion
             $('.email_hint').html text
           window.dispatchEvent(event)
         empty: (element) ->
-          event = new Event('mailcheck');
+          event = @buildEvent()
           $('.email_hint').html ''
           window.dispatchEvent(event)
 
     $(document).on 'click', '.email_hint .suggestion a.email_domain', (e) =>
       @trackUsage()
-      event = new Event('mailcheck');
+      event = @buildEvent()
       email_hint = $(e.originalEvent.target).parents('.email_hint')
       email = $(email_hint).prevAll('input[type=email]:last')
       $(email).val $('.suggestion').first().text()
       $('.email_hint').remove()
       window.dispatchEvent(event)
+
+  buildEvent: () ->
+    if typeof(Event) is 'function'
+      new Event('mailcheck')
+    else
+      document.createEvent('Event').initEvent('mailcheck', true, true)
 
   suggestionMarkup: (address, domain) ->
     "Did you mean " +

--- a/lib/ama_layout/version.rb
+++ b/lib/ama_layout/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AmaLayout
-  VERSION = '11.4.0'
+  VERSION = '11.5.0'
 end


### PR DESCRIPTION
* Modify the mailcheck function to dispatch a `mailcheck` event
  on the `window` element of the DOM. We need this because there's
  a few places that we need to send a change of height message to
  client applications.
* No longer use the `fadeIn` action to show the email suggestion.
  We'd like to deterministically fetch the element height and
  jQuery animations are "so 2013" :)

SEE: https://dev.azure.com/AMA-Ent/AMA-Ent/_workitems/edit/19604

