### PR TITLE
ADO-19604 - Support

### DIFF
--- a/app/assets/javascripts/ama_layout/mailcheck/email_suggestion.coffee
+++ b/app/assets/javascripts/ama_layout/mailcheck/email_suggestion.coffee
@@ -61,7 +61,7 @@ class AMALayout.EmailSuggestion
           else
             $('.email_hint').html text
           window.dispatchEvent(event)
-        empty: (element) ->
+        empty: (element) =>
           event = @buildEvent()
           $('.email_hint').html ''
           window.dispatchEvent(event)

--- a/lib/ama_layout/version.rb
+++ b/lib/ama_layout/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AmaLayout
-  VERSION = '11.5.0'
+  VERSION = '11.5.1'
 end


### PR DESCRIPTION
* Use the fat arrow (=>) syntax for the callback when mailcheck
  results are empty to be able to correctly call `this.buildEvent()`.

SEE: https://dev.azure.com/AMA-Ent/AMA-Ent/_workitems/edit/19604